### PR TITLE
ﾃﾞｭｱﾃﾞｭｱ!括弧間違ってるﾃﾞｭｱ!!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 #ignore pls
 files/*
 !files/kairun.wav
+private/*
 access.log
 
 # Logs

--- a/Routes/api/index.js
+++ b/Routes/api/index.js
@@ -103,7 +103,7 @@ function str2bool(str) {
 router.post("/upload-discord", async (req, res) => {
     let file = req.files.file;
     if (!file) return res.status(400);
-    let uploadDir = str2bool[req.query["private"]] ? prvDir : filesDir;
+    let uploadDir = str2bool(req.query["private"]) ? prvDir : filesDir;
     if (!fs.existsSync(uploadDir)) return res.sendStatus(404);
     let check = ipRangeCheck(req.ip, [
         "127.0.0.1/8",//ループバックアドレス


### PR DESCRIPTION
## 概要
private かに関わらず upload 先ディレクトリが常に通常のディレクトリだった問題を修正

## 変更点
* `str2bool` 関数の呼び出しの括弧が `[]` になっていたので修正
* `/.gitignore` に `/private/*` を追加 (ただのついで)